### PR TITLE
feat: HttpExceptionFilter 만들어보기

### DIFF
--- a/src/common/interceptor/http.exception-filter.ts
+++ b/src/common/interceptor/http.exception-filter.ts
@@ -1,0 +1,23 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException } from '@nestjs/common';
+
+@Catch(HttpException)
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const context = host.switchToHttp();
+    const response = context.getResponse();
+    const request = context.getRequest();
+    const status = exception.getStatus();
+
+    // 에러가 생겼다는 걸 어디에 알려줘야함
+    // 로그 파일을 생성하거나, 에러 모니터링 시스템에 API 콜 하기
+
+    response
+      .status(status)
+      .json({
+        statusCode: status,
+        message: exception.message,
+        timestamp: new Date().toLocaleString('kr'),
+        path: request.url,
+      })
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { ValidationPipe } from '@nestjs/common';
+import { HttpExceptionFilter } from './common/interceptor/http.exception-filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -21,6 +22,8 @@ async function bootstrap() {
     whitelist: true,
     forbidNonWhitelisted: true,
   }));
+  // 글로벌하게 에러핸들링을 하기 위해 사용
+  app.useGlobalFilters(new HttpExceptionFilter())
   await app.listen(3000);
 }
 bootstrap();

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -9,7 +10,7 @@ import {
   Patch,
   Post,
   Query,
-  UploadedFile,
+  UploadedFile, UseFilters,
   UseGuards, UseInterceptors,
 } from '@nestjs/common';
 import { PostsService } from './posts.service';
@@ -25,6 +26,7 @@ import { PostsImagesService } from './image/image.service';
 import { LogInterceptor } from '../common/interceptor/log.interceptor';
 import { TransactionInterceptor } from '../common/interceptor/transaction.interceptor';
 import { QueryRunner } from '../common/decorator/query-runner.decorator';
+import { HttpExceptionFilter } from '../common/interceptor/http.exception-filter';
 
 
 @Controller('posts')
@@ -37,10 +39,13 @@ export class PostsController {
   // 1) GET /posts
   // 모든 게시물을 조회하는 API
   @Get()
+  @UseFilters(HttpExceptionFilter)
   @UseInterceptors(LogInterceptor)
   getPosts(
     @Query() query: PaginatePostDto,
   ) {
+    // 에러 테스트해보기
+    throw new BadRequestException('에러가 발생했습니다.');
     return this.postsService.paginatePosts(query);
   }
 
@@ -117,6 +122,4 @@ export class PostsController {
   deletePost(@Param('id', ParseIntPipe) id: number) {
     return this.postsService.deletePost(id);
   }
-
-
 }


### PR DESCRIPTION
우리가 사용할 수 있는 HttpException들은 모두 HttpException을 상속받고 있다.

ExceptionFilter는 catch 메서드를 오버라이드해야하며 ExceptionFilter를 implements해야한다.
response의 상태를 받아 Json 형태로 바꿔 프론트에 전달할 수 있기도 하고
로직 사이에 로그 파일을 생성하거나 에러 모니터링 API를 호출하는 등에 사용할 수 있다.

main.ts에 app.useGlobalFilter를 사용해 글로벌하게 HttpException을 필터링할 수 있다.
